### PR TITLE
Emit 'close' events when query completes

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ QueryStream.prototype.handleCommandComplete = function(msg) {
 }
 
 QueryStream.prototype.handleReadyForQuery = function() {
+  this.emit('close')
   this.push(null)
 }
 


### PR DESCRIPTION
Consider a system where one component is scheduling tasks that yield
streams, and passing them to (unknown) clients for consumption.

It would be useful for the scheduler to know that the query
underlying the stream is completed (so it can continue on to it's
next task) without having to wait for the consumer to finish reading
all results.

My actual concrete use case is [any-db-transaction](https://github.com/grncdr/node-any-db-transaction) which only sees the stream object, but needs to perform it's next query without waiting for the consumer. I currently emit this event manually in [any-db-postgres](https://github.com/grncdr/node-any-db-postgres) but it seems like generally good stream behaviour so here we are :wink:
