### PR TITLE
Is it possible to destroy the stream?

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "~1.17.1"
   },
   "dependencies": {
-    "pg-cursor": "0.2.0",
+    "pg-cursor": "1.0.0",
     "readable-stream": "^1.0.27-1"
   }
 }

--- a/test/close.js
+++ b/test/close.js
@@ -4,12 +4,32 @@ var tester = require('stream-tester')
 var JSONStream = require('JSONStream')
 
 var QueryStream = require('../')
+var helper = require('./helper')
 
-require('./helper')('close', function(client) {
+helper('close', function(client) {
   it('emits close', function(done) {
     var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [3], {batchSize: 2, highWaterMark: 2})
     var query = client.query(stream)
     query.pipe(concat(function() {}))
     query.on('close', done)
+  })
+})
+
+helper('early close', function(client) {
+  it('can be closed early', function(done) {
+    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [20000], {batchSize: 2, highWaterMark: 2})
+    var query = client.query(stream)
+    var readCount = 0
+    query.on('readable', function() {
+      readCount++
+      query.read()
+    })
+    query.once('readable', function() {
+      query.close()
+    })
+    query.on('close', function() {
+      assert(readCount < 10, 'should not have read more than 10 rows')
+      done()
+    })
   })
 })

--- a/test/slow-reader.js
+++ b/test/slow-reader.js
@@ -1,0 +1,29 @@
+var assert = require('assert')
+var helper = require('./helper')
+var QueryStream = require('../')
+var concat = require('concat-stream')
+
+var Transform = require('stream').Transform
+
+var mapper = new Transform({objectMode: true})
+
+mapper._transform = function(obj, enc, cb) {
+    this.push(obj)
+    setTimeout(cb, 5)
+}
+
+helper('slow reader', function(client) {
+  it('works', function(done) {
+    this.timeout(50000)
+    var stream = new QueryStream('SELECT * FROM generate_series(0, 201) num', [], {highWaterMark: 100, batchSize: 50})
+    stream.on('end', function() {
+      //console.log('stream end')
+    })
+    var query = client.query(stream)
+    var result = []
+    var count = 0
+    stream.pipe(mapper).pipe(concat(function(res) {
+      done()
+    }))
+  })
+})


### PR DESCRIPTION
I have a scenario where I need to query a large number of rows and stop processing after some conditions are met, is it possible to programmatically close/destroy the stream, so that it stops reading results from the DB and it returns the connection to the pool, from inside the "data" event function?
