### PR TITLE
Avoid race when stream closed while fetching

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ QueryStream.prototype._read = function(n) {
     if(err) {
       return self.emit('error', err)
     }
+
+    if (self._closing) { return; }
+
     if(!rows.length) {
       process.nextTick(function() {
         self.push(null)

--- a/index.js
+++ b/index.js
@@ -32,10 +32,11 @@ for(var key in Cursor.prototype) {
   }
 }
 
-QueryStream.prototype.close = function() {
+QueryStream.prototype.close = function(cb) {
   this._closing = true
   var self = this
   Cursor.prototype.close.call(this, function(err) {
+    if (cb) { cb(err); }
     if(err) return self.emit('error', err)
     process.nextTick(function() {
       self.push(null)

--- a/test/close.js
+++ b/test/close.js
@@ -33,3 +33,50 @@ helper('early close', function(client) {
     })
   })
 })
+
+
+helper('should not throw errors after early close', function(client) {
+  it('can be closed early without error', function(done) {
+    var stream = new QueryStream('SELECT * FROM generate_series(0, 2000) num');
+    var query = client.query(stream);
+    var fetchCount = 0;
+    var errorCount = 0;
+
+
+    function waitForErrors() {
+
+      setTimeout(function () {
+        assert(errorCount === 0, 'should not throw a ton of errors');
+        done();
+      }, 10);
+    }
+
+    // hack internal _fetch function to force query.close immediately after _fetch is called (simulating the race condition)
+    // race condition: if close is called immediately after _fetch is called, but before results are returned, errors are thrown
+    // when the fetch results are pushed to the readable stream after its already closed.
+    query._fetch = (function (_fetch) {
+      return function () {
+
+        // wait for the second fetch.  closing immediately after the first fetch throws an entirely different error :(
+        if (fetchCount++ === 0) {
+          return _fetch.apply(this, arguments);
+        }
+
+        var results = _fetch.apply(this, arguments);
+
+        query.close();
+        waitForErrors();
+
+        query._fetch = _fetch; // we're done with our hack, so restore the original _fetch function.
+
+        return results;
+      }
+    }(query._fetch));
+
+    query.on('error', function () { errorCount++; });
+
+    query.on('readable', function () {
+      query.read();
+    });
+  });
+});


### PR DESCRIPTION
While working with node-pg-query-stream, I ran into an issue where the pg query stream was emitting large numbers of error events after I attempted to short-circuit the stream.

```JavaScript


pg.connect(function (err, client, cb) {

    var stream = new QueryStream('SELECT * FROM generate_series(0, 2000) num');
    var query = client.query(stream);

    var Writable = require('stream').Writable;
    var items = 0;

    var output = new Writable({ objectMode: true });
    output._write = function (json, encoding, cb) {
        process.nextTick(function () {
            cb(items++); // first will pass, second will fail.
        });
    };

    query.on('error', function (err) { console.error('ouch!', err); }); // will get thrown many time with "Error: stream.push() after EOF"
    output.on('error', function () {

        // downstream error.  let pg know we're done with the cursor before returning the client.
        query.close();
        cb();
    });

    output.on('finish', cb);
});

/* occasional console output:
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 ouch! Error: stream.push() after EOF
 . . .
 */


```


Also ran into an issue when trying the following in the code above:

```JavaScript

    output.on('error', function () {

        // downstream error.  let pg know we're done with the cursor before returning the client.
        query.once('close', cb);
        query.close();
    });

```

The close event never fired because I did not read to the end of the stream.

Thought about adding code to emit the 'close' event as soon as the cursor closed, but figured that would be too much of a breaking change.  Instead, added a callback to the stream's close function so that developers can do something like this to avoid returning the client to the pool before the cursor is actually closed:

```JavaScript

    output.on('error', function () {

        // downstream error.  let pg know we're done with the cursor before returning the client.
        query.close(cb);
    });

```
