### PR TITLE
Conform to readable stream spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "pg-cursor": "1.0.0",
-    "readable-stream": "^1.0.27-1"
+    "readable-stream": "^2.0.4"
   }
 }

--- a/test/fast-reader.js
+++ b/test/fast-reader.js
@@ -10,7 +10,13 @@ helper('fast reader', function(client) {
     var count = 0
     stream.on('readable', function() {
       var res = stream.read()
-      assert(res, 'should not return null on evented reader')
+      if (result.length !== 201) {
+        assert(res, 'should not return null on evented reader')
+      } else {
+        //a readable stream will emit a null datum when it finishes being readable
+        //https://nodejs.org/api/stream.html#stream_event_readable
+        assert.equal(res, null)
+      }
       if(res) {
         result.push(res.num)
       }


### PR DESCRIPTION
One of the tests was failing because it was testing that when a stream became readable it never returned a `null` datum on call to `stream.read()`.

In fact, when a readable stream drains it should & does return `null` for calls to `stream.read()` as described [here](https://nodejs.org/api/stream.html#stream_event_readable)

I updated the test to account for this, and they pass now.