### PR TITLE
Fix pg-cursor dependency for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "~1.17.1"
   },
   "dependencies": {
-    "pg-cursor": "1.0.0",
+    "pg-cursor": "^1.2.0",
     "readable-stream": "^2.0.4"
   }
 }


### PR DESCRIPTION
Just touching the dependent version of pg-cursor so I can build with Webpack.

For reference: https://github.com/brianc/node-pg-cursor/pull/19