### PR TITLE
Stop pushing data when push() returns false

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class PgQueryStream extends Readable {
     this.cursor = new Cursor(text, values)
     this._reading = false
     this._closed = false
+    this._buffer = []
     this.batchSize = (options || { }).batchSize || 100
 
     // delegate Submittable callbacks to cursor
@@ -35,7 +36,17 @@ class PgQueryStream extends Readable {
       return false
     }
     this._reading = true
-    const readAmount = Math.max(size, this.batchSize)
+    var readAmount = Math.max(size, this.batchSize)
+    var object;
+
+    while (object = this._buffer.shift()) {
+      readAmount--;
+      if (!this.push(object)) {
+        this._reading = false
+        return
+      }
+    }
+
     this.cursor.read(readAmount, (err, rows) => {
       if (this._closed) {
         return
@@ -52,8 +63,11 @@ class PgQueryStream extends Readable {
 
       // push each row into the stream
       this._reading = false
-      for (var i = 0; i < rows.length; i++) {
-        this.push(rows[i])
+      while (object = rows.shift()) {
+        if (!this.push(object)) {
+          this._buffer = this._buffer.concat(rows)
+          return
+        }
       }
     })
   }

--- a/test/pushes.js
+++ b/test/pushes.js
@@ -1,0 +1,33 @@
+var helper = require('./helper')
+var QueryStream = require('../')
+var Writable = require('stream').Writable
+var assert = require('assert')
+
+helper('pushes', function (client) {
+  it('stops pushing data when push() returns false and resumes on _read()', function (done) {
+    var readable = client.query(new QueryStream('SELECT * FROM generate_series(0, $1)', [500]))
+    var writable = new Writable({highWaterMark: 100, objectMode: true})
+    var shouldPushAgain = true
+
+    readable.original_read = readable._read
+    readable._read = function (size) {
+      shouldPushAgain = true
+      return this.original_read(size)
+    }
+
+    readable.originalPush = readable.push
+    readable.push = function (data) {
+      if (!shouldPushAgain && !(shouldPushAgain = this.originalPush(data))) {
+        assert(false)
+      } else {
+        return (shouldPushAgain = this.originalPush(data))
+      }
+    }
+
+    writable._write = function (chunk, encoding, callback) {
+      setImmediate(callback)
+    }
+
+    readable.pipe(writable).on('finish', done)
+  })
+})


### PR DESCRIPTION
Hello there,

According to the node.js documentation on [`readable._read`](https://nodejs.org/api/stream.html#stream_readable_read_size_1):
> _read() should continue reading from the resource and pushing data until readable.push() returns false. Only when _read() is called again after it has stopped should it resume pushing additional data onto the queue.

I think this is the way a `readable` stream is supposed to handle back-pressure. 

I found out that after calling `resume()` on a paused `readable`, node will immediately call `readable._read(size)` even it there's already a lot of data in the `readable`'s internal buffer.

A way of making sure not too much data gets allocated in the internal buffer is looking at the returned value of `readable.push()`, and take action according to the documentation.

I've made some modifications and also added a couple of tests to illustrate what these changes aim to fix.

Thank you, 